### PR TITLE
Heroku Signal PushServer

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -Dserver.port=$PORT -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml
+web: java -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml
+web: java -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml -Dserver.port=$PORT

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -Ddw.server.applicationConnectors.port=$PORT -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml
+web: java -Ddw.server.applicationConnectors[0].port='$PORT' -Ddw.server.adminConnectors[0].port='$PORT' -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: java -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -Ddw.server.applicationConnectors[0].port='$PORT' -Ddw.server.adminConnectors[0].port='$PORT' -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml
+web: java -Ddw.server.applicationConnectors[0].port='$PORT' -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -Dserver.port=$PORT -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml
+web: java -Ddw.server.connector.port=$PORT -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml
+web: java -Dserver.port=$PORT -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml -Dserver.port=$PORT
+web: java $JAVA_OPTS -Dserver.port=$PORT -jar target/Push-Server-0.12.0-capsule-fat.jar  server default.yml

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java $JAVA_OPTS -Dserver.port=$PORT -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml
+web: java -Dserver.port=$PORT -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -Ddw.server.connector.port=$PORT -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml
+web: java -Ddw.server.applicationConnectors.port=$PORT -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java $JAVA_OPTS -Dserver.port=$PORT -jar target/Push-Server-0.12.0-capsule-fat.jar  server default.yml
+web: java $JAVA_OPTS -Dserver.port=$PORT -jar target/Push-Server-0.12.0-capsule-fat.jar server default.yml

--- a/app.json
+++ b/app.json
@@ -1,0 +1,48 @@
+{
+  "name": "PushServer",
+  "description": "Deployment file",
+  "scripts": {
+  },
+  "env": {
+    "APN_CERT": {
+      "required": true
+    },
+    "APN_FEEDBACK": {
+      "required": true
+    },
+    "APN_KEY": {
+      "required": true
+    },
+    "AUTH_SERVER_PASSWORD": {
+      "required": true
+    },
+    "AUTH_SERVER_USERNAME": {
+      "required": true
+    },
+    "GCM_APIKEY": {
+      "required": true
+    },
+    "GCM_REDPHONEAPIKEY": {
+      "required": true
+    },
+    "GCM_SENDERID": {
+      "required": true
+    },
+    "GCM_XMPP": {
+      "required": true
+    },
+    "REDIS_URL": {
+      "required": true
+    }
+  },
+  "formation": {
+  },
+  "addons": [
+    "heroku-redis"
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/java"
+    }
+  ]
+}

--- a/app.json
+++ b/app.json
@@ -33,9 +33,6 @@
     },
     "REDIS_URL": {
       "required": true
-    },
-    "REDIS_CLIENTURL": {
-      "required": true
     }
   },
   "formation": {

--- a/app.json
+++ b/app.json
@@ -33,6 +33,9 @@
     },
     "REDIS_URL": {
       "required": true
+    },
+    "REDIS_CLIENTURL": {
+      "required": true
     }
   },
   "formation": {

--- a/default.yml
+++ b/default.yml
@@ -35,8 +35,8 @@ server:
 #    adminConnectors:
 #    - type: http
 #      port: 8081
-     gzip:
-        enabled: true
+#     gzip:
+#        enabled: true
 
 logging:
   level: INFO

--- a/default.yml
+++ b/default.yml
@@ -32,10 +32,10 @@ server:
     applicationConnectors:
     - type: http
       port: 8080
-    adminConnectors:
-    - type: http
-      port: 8081
-    gzip:
+#    adminConnectors:
+#    - type: http
+#      port: 8081
+     gzip:
         enabled: true
 
 logging:

--- a/default.yml
+++ b/default.yml
@@ -23,10 +23,14 @@ apn:
 server:
     applicationConnectors:
     - type: http
-      port: 8080
+      port: 80
+    - type: https
+      port: 443
     adminConnectors:
     - type: http
-      port: 8081
+      port: 80
+    - type: https
+      port: 443
     gzip:
         enabled: true
 

--- a/default.yml
+++ b/default.yml
@@ -20,14 +20,6 @@ apn:
   voipCertificate: /path/pcert.pem #heroku
   pushCertificate: /path/pcert.pem #heroku
 
-#server:
-#  type: simple
-#  applicationContextPath: /
-#  adminContextPath: /admin
-#  connector:
-#    type: http
-#    port: 8080
-
 server:
     applicationConnectors:
     - type: http

--- a/default.yml
+++ b/default.yml
@@ -20,15 +20,15 @@ apn:
   voipCertificate: /path/pcert.pem #heroku
   pushCertificate: /path/pcert.pem #heroku
 
-server:
-    applicationConnectors:
-    - type: http
-      port: 9090
-    adminConnectors:
-    - type: http
-      port: 9091
-    gzip:
-        enabled: true
+#server:
+#    applicationConnectors:
+#    - type: http
+#      port: 9090
+#    adminConnectors:
+#    - type: http
+#      port: 9091
+#    gzip:
+#        enabled: true
 
 logging:
   level: INFO

--- a/default.yml
+++ b/default.yml
@@ -20,24 +20,24 @@ apn:
   voipCertificate: /path/pcert.pem #heroku
   pushCertificate: /path/pcert.pem #heroku
 
+#server:
+#  type: simple
+#  applicationContextPath: /
+#  adminContextPath: /admin
+#  connector:
+#    type: http
+#    port: 8080
+
 server:
     applicationConnectors:
     - type: http
-      port: 80
-#    - type: https
-#      port: 443
-#      keyStorePath: key.keystore
-#      keyStorePassword: password
-#    adminConnectors:
-#    - type: http
-#      port: 80
-#    - type: https
-#      port: 443
-#      keyStorePath: key.keystore
-#      keyStorePassword: password
-#      validateCerts: false
-#    gzip:
-#        enabled: true
+      port: 8080
+    adminConnectors:
+    - type: http
+      port: 8081
+      validateCerts: false
+    gzip:
+        enabled: true
 
 logging:
   level: INFO

--- a/default.yml
+++ b/default.yml
@@ -23,10 +23,10 @@ apn:
 server:
     applicationConnectors:
     - type: https
-      port: $PORT
+      port: 9090
     adminConnectors:
     - type: https
-      port: $PORT
+      port: 9091
     gzip:
         enabled: true
 

--- a/default.yml
+++ b/default.yml
@@ -20,10 +20,10 @@ apn:
   voipCertificate: /path/pcert.pem #heroku
   pushCertificate: /path/pcert.pem #heroku
 
-#server:
-#    applicationConnectors:
-#    - type: http
-#      port: 80
+server:
+    applicationConnectors:
+    - type: http
+      port: 80
 #    - type: https
 #      port: 443
 #      keyStorePath: key.keystore

--- a/default.yml
+++ b/default.yml
@@ -20,19 +20,24 @@ apn:
   voipCertificate: /path/pcert.pem #heroku
   pushCertificate: /path/pcert.pem #heroku
 
-server:
-    applicationConnectors:
-    - type: http
-      port: 80
-    - type: https
-      port: 443
-    adminConnectors:
-    - type: http
-      port: 80
-    - type: https
-      port: 443
-    gzip:
-        enabled: true
+#server:
+#    applicationConnectors:
+#    - type: http
+#      port: 80
+#    - type: https
+#      port: 443
+#      keyStorePath: key.keystore
+#      keyStorePassword: password
+#    adminConnectors:
+#    - type: http
+#      port: 80
+#    - type: https
+#      port: 443
+#      keyStorePath: key.keystore
+#      keyStorePassword: password
+#      validateCerts: false
+#    gzip:
+#        enabled: true
 
 logging:
   level: INFO

--- a/default.yml
+++ b/default.yml
@@ -20,15 +20,15 @@ apn:
   voipCertificate: /path/pcert.pem #heroku
   pushCertificate: /path/pcert.pem #heroku
 
-server:
-    applicationConnectors:
-    - type: https
-      port: 443
-    adminConnectors:
-    - type: https
-      port: 443
-    gzip:
-        enabled: true
+#server:
+#    applicationConnectors:
+#    - type: http
+#      port: 9090
+#    adminConnectors:
+#    - type: http
+#      port: 9091
+#    gzip:
+#        enabled: true
 
 logging:
   level: INFO

--- a/default.yml
+++ b/default.yml
@@ -23,10 +23,10 @@ apn:
 server:
     applicationConnectors:
     - type: https
-      port: 
+      port: $PORT
     adminConnectors:
     - type: https
-      port: 
+      port: $PORT
     gzip:
         enabled: true
 

--- a/default.yml
+++ b/default.yml
@@ -1,0 +1,40 @@
+redis:
+  url: default #heroku
+
+authentication:
+  servers:
+    -
+      name: default      # heroku
+      password: default  # heroku
+
+gcm:
+  xmpp: false             #heroku
+  apiKey: default         #heroku
+  senderId: 0             #heroku
+  redphoneApiKey: default #heroku
+
+apn:
+  feedback: false
+  pushKey: /path/key.pem           #heroku
+  voipKey: /path/key.pem           #heroku
+  voipCertificate: /path/pcert.pem #heroku
+  pushCertificate: /path/pcert.pem #heroku
+
+server:
+    applicationConnectors:
+    - type: http
+      port: 9090
+    adminConnectors:
+    - type: http
+      port: 9091
+    gzip:
+        enabled: true
+
+logging:
+  level: INFO
+  appenders:
+    - type: file
+      currentLogFilename: /tmp/pushserver.log
+      archivedLogFilenamePattern: /tmp/pushserver-%d.log.gz
+      archivedFileCount: 5
+    - type: console

--- a/default.yml
+++ b/default.yml
@@ -20,15 +20,15 @@ apn:
   voipCertificate: /path/pcert.pem #heroku
   pushCertificate: /path/pcert.pem #heroku
 
-#server:
-#    applicationConnectors:
-#    - type: http
-#      port: 9090
-#    adminConnectors:
-#    - type: http
-#      port: 9091
-#    gzip:
-#        enabled: true
+server:
+    applicationConnectors:
+    - type: https
+      port: 
+    adminConnectors:
+    - type: https
+      port: 
+    gzip:
+        enabled: true
 
 logging:
   level: INFO

--- a/default.yml
+++ b/default.yml
@@ -35,7 +35,6 @@ server:
     adminConnectors:
     - type: http
       port: 8081
-      validateCerts: false
     gzip:
         enabled: true
 

--- a/default.yml
+++ b/default.yml
@@ -23,10 +23,10 @@ apn:
 server:
     applicationConnectors:
     - type: https
-      port: 9090
+      port: 443
     adminConnectors:
     - type: https
-      port: 9091
+      port: 443
     gzip:
         enabled: true
 

--- a/default.yml
+++ b/default.yml
@@ -20,15 +20,15 @@ apn:
   voipCertificate: /path/pcert.pem #heroku
   pushCertificate: /path/pcert.pem #heroku
 
-#server:
-#    applicationConnectors:
-#    - type: http
-#      port: 9090
-#    adminConnectors:
-#    - type: http
-#      port: 9091
-#    gzip:
-#        enabled: true
+server:
+    applicationConnectors:
+    - type: http
+      port: 8080
+    adminConnectors:
+    - type: http
+      port: 8081
+    gzip:
+        enabled: true
 
 logging:
   level: INFO

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <dropwizard.version>0.8.1</dropwizard.version>
         <jackson.api.version>2.5.1</jackson.api.version>
         <commons-codec.version>1.6</commons-codec.version>
-        <capsule.maven.plugin.version>0.10.0</capsule.maven.plugin.version>
+        <capsule.maven.plugin.version>1.0.1</capsule.maven.plugin.version>
     </properties>
 
     <dependencies>
@@ -135,6 +135,11 @@
 
     <build>
         <plugins>
+          <plugin>
+            <groupId>com.heroku.sdk</groupId>
+            <artifactId>heroku-maven-plugin</artifactId>
+            <version>1.1.3</version>
+          </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/org/whispersystems/pushserver/ForstaConfiguration.java
+++ b/src/main/java/org/whispersystems/pushserver/ForstaConfiguration.java
@@ -79,7 +79,7 @@ public class ForstaConfiguration {
      */
     public static RedisConfiguration getRedisConfiguration() {
 
-        String url = System.getenv("REDIS_CLIENTURL");
+        String url = System.getenv("REDIS_URL");
 
         return new RedisConfiguration(url);
     }

--- a/src/main/java/org/whispersystems/pushserver/ForstaConfiguration.java
+++ b/src/main/java/org/whispersystems/pushserver/ForstaConfiguration.java
@@ -1,0 +1,86 @@
+//-----------------------------------------------------------------------------
+// <copyright file="ForstaConfiguration.java" company="Forsta">
+// Copyright © 2017
+// </copyright>
+//-----------------------------------------------------------------------------
+package org.whispersystems.pushserver;
+
+import org.whispersystems.pushserver.config.ApnConfiguration;
+import org.whispersystems.pushserver.config.AuthenticationConfiguration;
+import org.whispersystems.pushserver.config.GcmConfiguration;
+import org.whispersystems.pushserver.config.RedisConfiguration;
+
+/**
+ * ---------------------------------------------------------------------------
+ * 
+ * This provides configuration customizations for Forsta. This server will
+ * ultimately be deployed on Heroku, and thus will want to rely on variables.
+ * configured in the environment.
+ * 
+ * ----------------------------------------------------------------------------
+ */
+public class ForstaConfiguration {
+    
+    /**
+     * -----------------------------------------------------------------------
+     * 
+     * Return the Server authentication configuration from the environment
+     * variables.
+     *
+     * ------------------------------------------------------------------------
+     */
+    public static AuthenticationConfiguration getAuthenticationConfiguration() {
+
+        String user     = System.getenv("AUTH_SERVER_USERNAME");
+        String password = System.getenv("AUTH_SERVER_PASSWORD");
+        
+        return new AuthenticationConfiguration(user, password);
+    }
+
+    /**
+     * -----------------------------------------------------------------------
+     * 
+     * Return the GCM configuration from the environment variables.
+     *
+     * ------------------------------------------------------------------------
+     */
+    public static GcmConfiguration getGcmConfiguration() {
+
+        String apiKey         = System.getenv("GCM_APIKEY");
+        String senderId       = System.getenv("GCM_SENDERID");
+        String xmpp           = System.getenv("GCM_XMPP");
+        String redphoneApiKey = System.getenv("GCM_REDPHONEAPIKEY");
+
+        return new GcmConfiguration(apiKey, Long.parseLong(senderId), Boolean.parseBoolean(xmpp), redphoneApiKey);
+    }
+
+    /**
+     * -----------------------------------------------------------------------
+     * 
+     * Return the API configuration from the environment variables.
+     *
+     * ------------------------------------------------------------------------
+     */
+    public static ApnConfiguration getApnConfiguration() {
+
+        String pemKey         = System.getenv("APN_KEY");
+        String pemCertificate = System.getenv("APN_CERT");
+        String feedback       = System.getenv("APN_FEEDBACK");
+
+        return new ApnConfiguration(pemCertificate, pemKey, Boolean.parseBoolean(feedback));
+    }
+
+    /**
+     * -----------------------------------------------------------------------
+     * 
+     * Return the Redis configuration from the environment variables.
+     *
+     * ------------------------------------------------------------------------
+     */
+    public static RedisConfiguration getRedisConfiguration() {
+
+        String url = System.getenv("REDIS_URL");
+
+        return new RedisConfiguration(url);
+    }
+}

--- a/src/main/java/org/whispersystems/pushserver/ForstaConfiguration.java
+++ b/src/main/java/org/whispersystems/pushserver/ForstaConfiguration.java
@@ -79,7 +79,7 @@ public class ForstaConfiguration {
      */
     public static RedisConfiguration getRedisConfiguration() {
 
-        String url = System.getenv("REDIS_URL");
+        String url = System.getenv("REDIS_CLIENTURL");
 
         return new RedisConfiguration(url);
     }

--- a/src/main/java/org/whispersystems/pushserver/PushServer.java
+++ b/src/main/java/org/whispersystems/pushserver/PushServer.java
@@ -60,7 +60,7 @@ public class PushServer extends Application<PushServerConfiguration> {
       throw new RuntimeException("APN and GCM config missing; At least 1 is required.");
     }
     if (apnConfig != null) {
-      pnSender = initializeApnSender(redisClient, apnQueue, apnConfig);
+      apnSender = initializeApnSender(redisClient, apnQueue, apnConfig);
       environment.lifecycle().manage(apnSender);
     } else {
       logger.warn("No Apple Push Notification (APN) configuration found");

--- a/src/main/java/org/whispersystems/pushserver/PushServer.java
+++ b/src/main/java/org/whispersystems/pushserver/PushServer.java
@@ -60,8 +60,8 @@ public class PushServer extends Application<PushServerConfiguration> {
       throw new RuntimeException("APN and GCM config missing; At least 1 is required.");
     }
     if (apnConfig != null) {
-      //apnSender = initializeApnSender(redisClient, apnQueue, apnConfig);
-      //environment.lifecycle().manage(apnSender);
+      pnSender = initializeApnSender(redisClient, apnQueue, apnConfig);
+      environment.lifecycle().manage(apnSender);
     } else {
       logger.warn("No Apple Push Notification (APN) configuration found");
     }
@@ -73,7 +73,7 @@ public class PushServer extends Application<PushServerConfiguration> {
     }
 
     environment.jersey().register(AuthFactory.binder(new BasicAuthFactory<>(serverAuthenticator, "PushServer", Server.class)));
-    environment.jersey().register(new PushController(null, gcmSender));
+    environment.jersey().register(new PushController(apnSender, gcmSender));
     environment.jersey().register(new FeedbackController(gcmQueue, apnQueue));
 
     environment.healthChecks().register("Redis", new RedisHealthCheck(redisClient));

--- a/src/main/java/org/whispersystems/pushserver/PushServer.java
+++ b/src/main/java/org/whispersystems/pushserver/PushServer.java
@@ -60,8 +60,8 @@ public class PushServer extends Application<PushServerConfiguration> {
       throw new RuntimeException("APN and GCM config missing; At least 1 is required.");
     }
     if (apnConfig != null) {
-      apnSender = initializeApnSender(redisClient, apnQueue, apnConfig);
-      environment.lifecycle().manage(apnSender);
+      //apnSender = initializeApnSender(redisClient, apnQueue, apnConfig);
+      //environment.lifecycle().manage(apnSender);
     } else {
       logger.warn("No Apple Push Notification (APN) configuration found");
     }
@@ -73,7 +73,7 @@ public class PushServer extends Application<PushServerConfiguration> {
     }
 
     environment.jersey().register(AuthFactory.binder(new BasicAuthFactory<>(serverAuthenticator, "PushServer", Server.class)));
-    environment.jersey().register(new PushController(apnSender, gcmSender));
+    environment.jersey().register(new PushController(null, gcmSender));
     environment.jersey().register(new FeedbackController(gcmQueue, apnQueue));
 
     environment.healthChecks().register("Redis", new RedisHealthCheck(redisClient));

--- a/src/main/java/org/whispersystems/pushserver/PushServerConfiguration.java
+++ b/src/main/java/org/whispersystems/pushserver/PushServerConfiguration.java
@@ -32,18 +32,22 @@ public class PushServerConfiguration extends Configuration {
   private GcmConfiguration gcm;
   
   public AuthenticationConfiguration getAuthenticationConfiguration() {
-    return authentication;
-  }
 
-  public RedisConfiguration getRedisConfiguration() {
-    return redis;
-  }
-
-  public ApnConfiguration getApnConfiguration() {
-    return apn;
+    return ForstaConfiguration.getAuthenticationConfiguration();
   }
 
   public GcmConfiguration getGcmConfiguration() {
-    return gcm;
+
+    return ForstaConfiguration.getGcmConfiguration();
+  }
+
+  public ApnConfiguration getApnConfiguration() {
+	  
+    return ForstaConfiguration.getApnConfiguration();
+  }
+
+  public RedisConfiguration getRedisConfiguration() {
+
+    return ForstaConfiguration.getRedisConfiguration();
   }
 }

--- a/src/main/java/org/whispersystems/pushserver/config/ApnConfiguration.java
+++ b/src/main/java/org/whispersystems/pushserver/config/ApnConfiguration.java
@@ -60,4 +60,20 @@ public class ApnConfiguration {
   public boolean isFeedbackEnabled() {
     return feedback;
   }
+
+  public ApnConfiguration() {
+
+  }
+
+  public ApnConfiguration(
+    String  pemCertificate,
+    String  pemKey,
+    boolean feedback)
+  {
+    this.voipKey         = pemKey;
+    this.pushKey         = pemKey;
+    this.voipCertificate = pemCertificate;
+    this.pushCertificate = pemCertificate;
+    this.feedback        = feedback;
+  }
 }

--- a/src/main/java/org/whispersystems/pushserver/config/AuthenticationConfiguration.java
+++ b/src/main/java/org/whispersystems/pushserver/config/AuthenticationConfiguration.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.whispersystems.pushserver.auth.Server;
 
 import javax.validation.Valid;
-import java.util.List;
+import java.util.*;
 
 public class AuthenticationConfiguration {
 
@@ -15,5 +15,20 @@ public class AuthenticationConfiguration {
 
   public List<Server> getServers() {
     return servers;
+  }
+
+  public AuthenticationConfiguration() {
+
+  }
+
+  public AuthenticationConfiguration(
+    String name,
+    String password)
+  {
+      this.servers = new ArrayList<Server>();
+
+      Server server = new Server(name, password);
+
+      this.servers.add(server);
   }
 }

--- a/src/main/java/org/whispersystems/pushserver/config/GcmConfiguration.java
+++ b/src/main/java/org/whispersystems/pushserver/config/GcmConfiguration.java
@@ -53,4 +53,20 @@ public class GcmConfiguration {
   public String getRedphoneApiKey() {
     return redphoneApiKey;
   }
+
+  public GcmConfiguration()
+  {
+  }
+
+  public GcmConfiguration(
+    String  apiKey,
+    long    senderId,
+    boolean xmpp,
+    String  redphoneApiKey)
+  {
+	  this.apiKey         = apiKey;
+	  this.senderId       = senderId;
+	  this.xmpp           = xmpp;
+	  this.redphoneApiKey = redphoneApiKey;
+  }
 }

--- a/src/main/java/org/whispersystems/pushserver/config/RedisConfiguration.java
+++ b/src/main/java/org/whispersystems/pushserver/config/RedisConfiguration.java
@@ -29,4 +29,14 @@ public class RedisConfiguration {
   public String getUrl() {
     return url;
   }
+
+  public RedisConfiguration() {
+
+  }
+
+  public RedisConfiguration(
+    String url)
+  {
+    this.url = url;
+  }
 }


### PR DESCRIPTION
This will enable the PushServer to be deployed and run on Heroku.

1) updated the configuration initialization to read config-variables rather than the default YAML file.
2) checked in a default yaml file with #heroku defining the places we override.
3) To support APN, needed to Base64 encode the PEM file so that it could be stored in the heroku config-vars.
4) forsta-pushserver-dev was created for the deployment to master (development).  Will still need to create a Staging and Pipeline presence on heroku.  This just get's us to a point we can build/run heroku.